### PR TITLE
Update getLocations filters

### DIFF
--- a/cdm_protobuf.proto
+++ b/cdm_protobuf.proto
@@ -70,7 +70,7 @@ message GetLocationsRequest {
   optional uint32 n_recent = 1;
   optional double timeBegin = 2;
   optional double timeEnd = 3;
-  optional string identifier = 4;
+  repeated string identifier = 4;
 }
 
 message GetLocationsResponse {

--- a/cdm_protobuf.proto
+++ b/cdm_protobuf.proto
@@ -65,19 +65,12 @@ message Location {
   optional double y = 4;
 }
 
-enum GetLocationsBy {
-  IDENTIFIER = 0;
-  INTERVAL = 1;
-  N_RECENT = 2;
-  ALL = 3;
-}
-
 // Location get
 message GetLocationsRequest {
-  GetLocationsBy method = 1;
-  optional string identifier = 2;
-  optional double timeinterval = 3;
-  optional uint32 n_recent = 4;
+  optional uint32 n_recent = 1;
+  optional double timeBegin = 2;
+  optional double timeEnd = 3;
+  optional string identifier = 4;
 }
 
 message GetLocationsResponse {


### PR DESCRIPTION
GetLocations now works by defaulting to sending all locations, but you can specify filters that limit the query. This way you can also combine different filters.

The `timeInterval` filter has been updated to include a begin and end time for the collected locations.

You can now specify more than one location to get simultaneously.

The `n-recent` is expected to start at `timeBegin` if that is defined.

We expect the server to set a default `n_recent` to something like `1000` to limit default queries. The client can override this if it wants more.